### PR TITLE
Do not generate single-line comments

### DIFF
--- a/core/src/jvmMain/kotlin/io/kinference/compiler/generation/ModelClassGenerator.kt
+++ b/core/src/jvmMain/kotlin/io/kinference/compiler/generation/ModelClassGenerator.kt
@@ -189,7 +189,7 @@ class ModelClassGenerator(
 
     private fun generateOperatorScope(operator: Operator<*, *>, operatorIndex: Int): CodeBlock =
         CodeBlock.builder().apply {
-            addLine("// ${operator.info.name}")
+            addLine("/* ${operator.info.name} */")
             withControlFlow("run") {
                 add(OperatorGenerator(operator, info = OperatorGenerationInfo(
                     nameMapping,

--- a/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/common/MultidirectionalBroadcastingOperatorGenerator.kt
+++ b/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/common/MultidirectionalBroadcastingOperatorGenerator.kt
@@ -80,7 +80,7 @@ abstract class MultidirectionalBroadcastingOperatorGenerator(
             }
             val output = operator.outputs[0]
             addLine(
-                "%L = %T(array = resultArray, strides = resultStrides) // %L",
+                "%L = %T(array = resultArray, strides = resultStrides) /* %L */",
                 nameMapping(output),
                 resultType.ndArrayTypeName(),
                 output

--- a/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/common/TypeAndShapeAwareOperatorGenerator.kt
+++ b/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/common/TypeAndShapeAwareOperatorGenerator.kt
@@ -34,7 +34,7 @@ abstract class TypeAndShapeAwareOperatorGenerator(
         builder.apply {
             if (inputsToInfer.all { tensorInfo.containsKey(it) }) {
                 operator.inputs.forEachIndexed { index, input ->
-                    addLine("val input$index = %L // %L", nameMapping(input), input)
+                    addLine("val input$index = %L /* %L */", nameMapping(input), input)
                 }
 
                 resultInfo().forEach { (name, info) ->

--- a/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/math/MatMulGenerator.kt
+++ b/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/math/MatMulGenerator.kt
@@ -79,7 +79,7 @@ class MatMulGenerator(
             }
             val output = operator.outputs.first()
             addLine(
-                "%L = result // %L",
+                "%L = result /* %L */",
                 nameMapping(output),
                 output
             )

--- a/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/tensor/ConcatGenerator.kt
+++ b/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/tensor/ConcatGenerator.kt
@@ -106,7 +106,7 @@ class ConcatGenerator(
             }
             val output = operator.outputs.first()
             addLine(
-                "%L = %T(array = resultArray, strides = resultStrides) // %L",
+                "%L = %T(array = resultArray, strides = resultStrides) /* %L */",
                 nameMapping(output),
                 resultType.ndArrayTypeName(),
                 output

--- a/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/tensor/GatherGenerator.kt
+++ b/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/tensor/GatherGenerator.kt
@@ -151,7 +151,7 @@ class GatherGenerator(
             }
             val output = operator.outputs[0]
             addLine(
-                "%L = %T(array = resultArray, strides = resultStrides) // %L",
+                "%L = %T(array = resultArray, strides = resultStrides) /* %L */",
                 nameMapping(output),
                 resultType.ndArrayTypeName(),
                 output

--- a/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/tensor/TransposeGenerator.kt
+++ b/core/src/jvmMain/kotlin/io/kinference/compiler/generation/operators/tensor/TransposeGenerator.kt
@@ -131,7 +131,7 @@ class TransposeGenerator(
 
             val output = operator.outputs.first()
             addLine(
-                "%L = %T(array = %T(blocks = resultBlocks), strides = %T(shape = intArrayOf(${resultShape.joinToString()}))) // %L",
+                "%L = %T(array = %T(blocks = resultBlocks), strides = %T(shape = intArrayOf(${resultShape.joinToString()}))) /* %L */",
                 nameMapping(output),
                 resultType.ndArrayTypeName(),
                 resultType.tiledArrayTypeName(),


### PR DESCRIPTION
KotlinPoet may split single-line comments into multiple lines, so it is safer not to generate them.